### PR TITLE
Post query/loop in Twig template

### DIFF
--- a/inc/custom-widget.class.php
+++ b/inc/custom-widget.class.php
@@ -192,12 +192,11 @@ class SiteOrigin_Widget_Custom_Widget extends SiteOrigin_Widget {
 			'autoescape' => true,
 		) );
 
-		if( ! class_exists( 'SiteOrigin_Widget_Twig_Filters' ) ) {
-			include plugin_dir_path( __FILE__ ) . 'twig-filters.class.php';
+		if( ! class_exists( 'SiteOrigin_Widget_Twig_Extension' ) ) {
+			include plugin_dir_path( __FILE__ ) . 'twig-extension.class.php';
 		}
 
-		$twig->addFilter( new Twig_SimpleFilter('panels_render', array( 'SiteOrigin_Widget_Twig_Filters', 'panels_render' ) ) );
-		$twig->addFilter( new Twig_SimpleFilter('image', array( 'SiteOrigin_Widget_Twig_Filters', 'image' ) ) );
+		$twig->addExtension( new SiteOrigin_Widget_Twig_Extension() );
 
 		return $twig;
 	}

--- a/inc/twig-extension.class.php
+++ b/inc/twig-extension.class.php
@@ -1,0 +1,38 @@
+<?php
+class SiteOrigin_Widget_Twig_Extension extends Twig_Extension {
+
+	public function getName() {
+		return 'so-widget-builder';
+	}
+
+	public function getGlobals() {
+		if ( ! class_exists( 'SiteOrigin_Widget_Twig_Proxy' ) ) {
+			include plugin_dir_path( __FILE__ ) . 'twig-proxy.class.php';
+		}
+
+		return array(
+			'wp' => new SiteOrigin_Widget_Twig_Proxy(),
+		);
+	}
+
+	public function getFunctions() {
+		if ( ! class_exists( 'SiteOrigin_Widget_Twig_Functions' ) ) {
+			include plugin_dir_path( __FILE__ ) . 'twig-functions.class.php';
+		}
+
+		return array(
+			new Twig_SimpleFunction( 'so_query', array( 'SiteOrigin_Widget_Twig_Functions', 'so_query' ) ),
+		);
+	}
+
+	public function getFilters() {
+		if ( ! class_exists( 'SiteOrigin_Widget_Twig_Filters' ) ) {
+			include plugin_dir_path( __FILE__ ) . 'twig-filters.class.php';
+		}
+
+		return array(
+			new Twig_SimpleFilter('panels_render', array( 'SiteOrigin_Widget_Twig_Filters', 'panels_render' ) ),
+			new Twig_SimpleFilter('image', array( 'SiteOrigin_Widget_Twig_Filters', 'image' ) ),
+		);
+	}
+}

--- a/inc/twig-functions.class.php
+++ b/inc/twig-functions.class.php
@@ -1,0 +1,15 @@
+<?php
+
+class SiteOrigin_Widget_Twig_Functions {
+    
+    static function so_query( $query ) {
+		if ( ! class_exists( 'SiteOrigin_Widget_Twig_Query' ) ) {
+			include plugin_dir_path( __FILE__ ) . 'twig-query.class.php';
+		}
+
+	return function_exists( 'siteorigin_widget_post_selector_process_query' ) ?
+	    new SiteOrigin_Widget_Twig_Query( siteorigin_widget_post_selector_process_query ( $query ) ) :
+	    __( 'Page builder is required to render this field.', 'so-widgets-builder' );
+    }
+
+}

--- a/inc/twig-proxy.class.php
+++ b/inc/twig-proxy.class.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * The Proxy that allows us to use Wordpress functions in Twig Templates
+ */
+class SiteOrigin_Widget_Twig_Proxy {
+    public function __call( $function, $arguments ) {
+	if ( ! function_exists( $function ) ) {
+	    trigger_error( 'call to unexisting function ' . $function, E_USER_ERROR );
+	    return NULL;
+	}
+
+	return call_user_func_array( $function, $arguments );
+    }
+}

--- a/inc/twig-query.class.php
+++ b/inc/twig-query.class.php
@@ -1,0 +1,37 @@
+<?php
+class SiteOrigin_Widget_Twig_Query implements Iterator {
+    private $wp_query_args;
+    private $query;
+    private $have_post = FALSE;
+
+    public function __construct( $wp_query_args ) {
+	$this->wp_query_args = $wp_query_args;
+    }
+
+    function rewind() {
+	$this->query = new WP_Query( $this->wp_query_args );
+	$this->next();
+    }
+
+    function next() {
+	if ( $this->have_post = isset( $this->query ) && $this->query->have_posts() ) {
+	    $this->query->the_post();
+	}
+	else if ( isset( $this->query ) ) {
+	    wp_reset_postdata();
+	    unset( $this->query );
+	}
+    }
+
+    function current() {
+	return get_post();
+    }
+
+    function key() {
+	return get_the_ID();
+    }
+
+    function valid() {
+	return $this->have_post;
+    }
+}

--- a/src/widget.php
+++ b/src/widget.php
@@ -48,12 +48,11 @@ class _SiteOrigin_Widget_Custom_Widget extends SiteOrigin_Widget {
 			'autoescape' => true,
 		) );
 
-		if( ! class_exists( 'SiteOrigin_Widget_Twig_Filters' ) ) {
-			include plugin_dir_path( __FILE__ ) . '../../inc/twig-filters.class.php';
+		if( ! class_exists( 'SiteOrigin_Widget_Twig_Extension' ) ) {
+			include plugin_dir_path( __FILE__ ) . '../../inc/twig-extension.class.php';
 		}
 
-		$twig->addFilter( new Twig_SimpleFilter('panels_render', array( 'SiteOrigin_Widget_Twig_Filters', 'panels_render' ) ) );
-		$twig->addFilter( new Twig_SimpleFilter('image', array( 'SiteOrigin_Widget_Twig_Filters', 'image' ) ) );
+		$twig->addExtension( new SiteOrigin_Widget_Twig_Extension() );
 
 		return $twig;
 	}


### PR DESCRIPTION
Hi,

I was curious about this plugin so I gave it a try and found its power/simplicity ratio amazing. This PR makes the following work:

```
{% var posts = so_query(some_posts_variable) %}
{% if posts %}
    <ul>
    {% foreach post in posts %}
        <li>{{ wp.the_title() }}</li>
    {% endfor %}
    </ul>
{% endif %}
```

`so_query` function declared in `SiteOrigin_Widget_Twig_Functions` is the glue between WP, PageBuilder and Twig:
- It converts the input Page Builder post query variable into a WP query argument using `siteorigin_widget_post_selector_process_query`
- It returns an instance of `SiteOrigin_Widget_Twig_Query` class, which is an `Iterator` wrapped around `WP_Query`, `have_posts`, `the_post` and `wp_reset_postdata`.

WP (and other global) functions are accessed through the global `wp` proxy object using the code and idea from https://github.com/zach-adams/sprig.

`so_query`, `wp` and existing `panels_render` and `image` filters are registered in Twig using the extension class `SiteOrigin_Widget_Twig_Extension`.

yazide
